### PR TITLE
change purgecss config

### DIFF
--- a/template/nuxt.config.js
+++ b/template/nuxt.config.js
@@ -83,7 +83,7 @@ module.exports = {
   purgeCSS: {
     enabled: true,
     paths: [
-      'node_modules/aclu-vue-library/dist/*'
+      'node_modules/aclu-vue-library/src/components/**/*.vue'
     ]
 
   },


### PR DESCRIPTION
- purgecss seems to drop class selectors for dynamic status when targeting dist file. changed purgecss config to target src. 

related pr: https://github.com/aclu-national/dotorg-home-frontend/pull/338