### PR TITLE
make prettier not care about template block

### DIFF
--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -15,11 +15,22 @@ module.exports = {
   extends: [
     // https://github.com/vuejs/eslint-plugin-vue#priority-a-essential-error-prevention
     'plugin:vue/recommended',
-    'plugin:prettier/recommended'
+    'plugin:prettier-vue/recommended'
   ],
 
   // required to lint *.vue files
   plugins: [ 'vue' ],
+
+  settings: {
+    'prettier-vue': {
+      // Prettier only for script and style block
+      SFCBlocks: {
+        template: false,
+        script: true,
+        style: true
+      }
+    }
+  },
 
   // custom eslint rules
   rules: {
@@ -45,7 +56,9 @@ module.exports = {
     }],
 
     // Prettier options
-    'prettier/prettier': [ 'warn', {
+    'prettier-vue/prettier': [
+      'warn',
+      {
         semi: false,
         singleQuote: true,
         printWidth: 120,
@@ -55,17 +68,5 @@ module.exports = {
         eslintIntegration: true
       }
     ]
-  },
-
-  overrides: [
-    {
-      files: [
-        '**/__tests__/*.{j,t}s?(x)',
-        '**/tests/unit/**/*.spec.{j,t}s?(x)'
-      ],
-      env: {
-        jest: true
-      }
-    }
-  ]
-};
+  }
+}

--- a/template/package.json
+++ b/template/package.json
@@ -30,6 +30,7 @@
     "eslint-friendly-formatter": "^4.0.1",
     "eslint-loader": "^3.0.3",
     "eslint-plugin-prettier": "^3.1.2",
+    "eslint-plugin-prettier-vue": "^2.0.2",
     "eslint-plugin-vue": "6.0.1",
     "husky": "^3.1.0",
     "node-sass": "^4.13.0",


### PR DESCRIPTION
- make prettier not to care about <template> block, (using eslint-plugin-prettier-vue). We have conflicting rule between Prettier and Lint about single block level element, which ends up with endless error. This will help automatic lint fix much easier.