### PR TITLE
Bulma version 0.7.5 -> 0.8.2

### DIFF
--- a/template/assets/scss/mixins.scss
+++ b/template/assets/scss/mixins.scss
@@ -1,6 +1,12 @@
 @import 'assets/scss/variables.scss';
 @import '~bulma/sass/utilities/mixins';
 
+// Workaround for 'undefined variable' error when importing bulma mixins
+// https://github.com/jgthms/bulma/issues/2773
+@import "~bulma/sass/utilities/functions";
+@import "~bulma/sass/utilities/initial-variables";
+@import "~bulma/sass/utilities/derived-variables";
+
 // MIXINS
 @mixin font-family-compressed () {
   font-family: $aclu-sans-compressed;

--- a/template/package.json
+++ b/template/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@nuxtjs/axios": "^5.9.0",
-    "bulma": "^0.7.5",
+    "bulma": "^0.8.2",
     "nuxt": "~2.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
**(July 17 2020) the import order of the files is wrong in this PR, Hanbyul followed up here https://github.com/aclu-national/nuxt2-starter-template/pull/20**

- Updates the bulma version in the same way as [News](https://github.com/aclu-national/dotorg-news-frontend/pull/458), with a workaround for 'undefined variable' error when importing bulma mixins jgthms/bulma#2773.
- See also: aclu-national/aclu-vue-library#201

~Note: Should I also commit package-lock.json here? `npm install` was giving me an error related to the example package name `{{ name }}` and not actually installing packages, but maybe that's ok because this is just the template?~

For future reference: do not commit package-lock ☑️. 