### PR TITLE
add tags plugin with optimizely breakpoints

### DIFF
--- a/template/nuxt.config.js
+++ b/template/nuxt.config.js
@@ -81,7 +81,8 @@ module.exports = {
   plugins: [
     { src: '~plugins/aclu-vue-library', mode: 'server' },
     { src: '~plugins/heap', mode: 'client' },
-    { src: '~plugins/cookies', mode: 'client' }
+    { src: '~plugins/cookies', mode: 'client' },
+    { src: '~plugins/tags', mode: 'client' },
   ],
   /*
   ** Modules

--- a/template/plugins/tags.js
+++ b/template/plugins/tags.js
@@ -1,0 +1,47 @@
+export default ({ app }) => {
+  /**
+   * ScriptTag
+   * Use this to create script tags that will be injected into the <head>
+   */
+  function ScriptTag({ src = '', isAsync = false, runBefore = () => {}, runAfter = () => {} }) {
+    this.src = src
+    this.isAsync = isAsync
+    this.runBefore = runBefore
+    this.runAfter = runAfter
+
+    this.load = () => {
+      const e = document.createElement('script')
+      const ns = document.head.getElementsByTagName('script')
+      const n = ns[ns.length - 1]
+      e.type = 'text/javascript'
+      e.async = this.isAsync
+      e.src = this.src
+
+      this.runBefore()
+      n.parentNode.insertBefore(e, n.nextSibling)
+      e.onload = () => {
+        this.runAfter()
+      }
+    }
+  }
+
+  /**
+   * Optimizely Breakpoint
+   */
+  const optimizelyBreakpoint = new ScriptTag({
+    src: 'https://static.aclu.org/js/optimizelyBreakpoints.js',
+    isAsync: true,
+    runAfter: () => {
+      var userDefinedBreakpoints = [
+        { max: 768, name: 'mobile' },
+        { max: 960, name: 'tablet' },
+        { max: 1200, name: 'desktop' },
+        { max: Infinity, name: 'wide-desktop' }
+      ]
+      optimizelyBreakpoints.initialize(userDefinedBreakpoints)
+    }
+  })
+
+  // Tags will load in the order that they are listed
+  optimizelyBreakpoint.load()
+}


### PR DESCRIPTION
aclu-national/dotorg#38

please also review the code in this new static js file, which was created for this ticket:
https://static.aclu.org/js/optimizelyBreakpoints.js

we added a new custom attribute in optimizely called acluDeviceBreakpointCategory which should be updated on page load, and whenever a new breakpoint is crossed.

the value can be verified by looking at this object in the console: window['optimizely'].get('visitor').custom, and look at the attribute with the name acluDeviceBreakpointCategory

this calls a shared script from static.aclu.org, and passes in the values and names for the actual breakpoints, to make it more reusable.