### PR TITLE
get rid of mode of acluvl from plugin set up

### DIFF
--- a/template/nuxt.config.js
+++ b/template/nuxt.config.js
@@ -79,7 +79,7 @@ module.exports = {
   ** Plugins
   */
   plugins: [
-    { src: '~plugins/aclu-vue-library', mode: 'server' },
+    { src: '~plugins/aclu-vue-library' },
     { src: '~plugins/heap', mode: 'client' },
     { src: '~plugins/cookies', mode: 'client' }
   ],


### PR DESCRIPTION
- I thought 'server' is equivalent of ssr:true it is not (it means it is only for server. docs link: https://nuxtjs.org/guide/plugins/#object-syntax) This should fix the current problem